### PR TITLE
Change letter spacing unit for Android

### DIFF
--- a/assets/android/kotlin/CpdDark.kt
+++ b/assets/android/kotlin/CpdDark.kt
@@ -166,10 +166,10 @@ object DarkDesignTokens {
   val cpdFontLetterSpacingHeadingLg = 0
   val cpdFontLetterSpacingHeadingMd = 0
   val cpdFontLetterSpacingHeadingSm = 0
-  val cpdFontLetterSpacingBodyLg = 0.25px
-  val cpdFontLetterSpacingBodyMd = 0.25px
-  val cpdFontLetterSpacingBodySm = 0.4px
-  val cpdFontLetterSpacingBodyXs = 0.5px
+  val cpdFontLetterSpacingBodyLg = 0.015625em
+  val cpdFontLetterSpacingBodyMd = 0.017857em
+  val cpdFontLetterSpacingBodySm = 0.033333em
+  val cpdFontLetterSpacingBodyXs = 0.045454em
   val cpdFontSizeHeadingXl = 34
   val cpdFontSizeHeadingLg = 28
   val cpdFontSizeHeadingMd = 22

--- a/assets/android/kotlin/CpdDarkHc.kt
+++ b/assets/android/kotlin/CpdDarkHc.kt
@@ -166,10 +166,10 @@ object DarkHcDesignTokens {
   val cpdFontLetterSpacingHeadingLg = 0
   val cpdFontLetterSpacingHeadingMd = 0
   val cpdFontLetterSpacingHeadingSm = 0
-  val cpdFontLetterSpacingBodyLg = 0.25px
-  val cpdFontLetterSpacingBodyMd = 0.25px
-  val cpdFontLetterSpacingBodySm = 0.4px
-  val cpdFontLetterSpacingBodyXs = 0.5px
+  val cpdFontLetterSpacingBodyLg = 0.015625em
+  val cpdFontLetterSpacingBodyMd = 0.017857em
+  val cpdFontLetterSpacingBodySm = 0.033333em
+  val cpdFontLetterSpacingBodyXs = 0.045454em
   val cpdFontSizeHeadingXl = 34
   val cpdFontSizeHeadingLg = 28
   val cpdFontSizeHeadingMd = 22

--- a/assets/android/kotlin/CpdLight.kt
+++ b/assets/android/kotlin/CpdLight.kt
@@ -166,10 +166,10 @@ object LightDesignTokens {
   val cpdFontLetterSpacingHeadingLg = 0
   val cpdFontLetterSpacingHeadingMd = 0
   val cpdFontLetterSpacingHeadingSm = 0
-  val cpdFontLetterSpacingBodyLg = 0.25px
-  val cpdFontLetterSpacingBodyMd = 0.25px
-  val cpdFontLetterSpacingBodySm = 0.4px
-  val cpdFontLetterSpacingBodyXs = 0.5px
+  val cpdFontLetterSpacingBodyLg = 0.015625em
+  val cpdFontLetterSpacingBodyMd = 0.017857em
+  val cpdFontLetterSpacingBodySm = 0.033333em
+  val cpdFontLetterSpacingBodyXs = 0.045454em
   val cpdFontSizeHeadingXl = 34
   val cpdFontSizeHeadingLg = 28
   val cpdFontSizeHeadingMd = 22

--- a/assets/android/kotlin/CpdLightHc.kt
+++ b/assets/android/kotlin/CpdLightHc.kt
@@ -166,10 +166,10 @@ object LightHcDesignTokens {
   val cpdFontLetterSpacingHeadingLg = 0
   val cpdFontLetterSpacingHeadingMd = 0
   val cpdFontLetterSpacingHeadingSm = 0
-  val cpdFontLetterSpacingBodyLg = 0.25px
-  val cpdFontLetterSpacingBodyMd = 0.25px
-  val cpdFontLetterSpacingBodySm = 0.4px
-  val cpdFontLetterSpacingBodyXs = 0.5px
+  val cpdFontLetterSpacingBodyLg = 0.015625em
+  val cpdFontLetterSpacingBodyMd = 0.017857em
+  val cpdFontLetterSpacingBodySm = 0.033333em
+  val cpdFontLetterSpacingBodyXs = 0.045454em
   val cpdFontSizeHeadingXl = 34
   val cpdFontSizeHeadingLg = 28
   val cpdFontSizeHeadingMd = 22

--- a/tokens/platform-android.json
+++ b/tokens/platform-android.json
@@ -119,20 +119,24 @@
     "letter-spacing": {
       "body": {
         "xs": {
-          "value": "0.5px",
-          "type": "letterSpacing"
+          "value": "4.5454%",
+          "type": "letterSpacing",
+          "description": "px: 0.5px"
         },
         "sm": {
-          "value": "0.4px",
-          "type": "letterSpacing"
+          "value": "3.3333%",
+          "type": "letterSpacing",
+          "description": "px: 0.4px"
         },
         "md": {
-          "value": "0.25px",
-          "type": "letterSpacing"
+          "value": "1.7857%",
+          "type": "letterSpacing",
+          "description": "px: 0.25px"
         },
         "lg": {
-          "value": "0.25px",
-          "type": "letterSpacing"
+          "value": "1.5625%",
+          "type": "letterSpacing",
+          "description": "px: 0.25px"
         }
       },
       "heading": {


### PR DESCRIPTION
Change from `px` to `%` for letter spacing on Android, as per the [updated spec](https://github.com/vector-im/compound-internal/pull/20).

I added the `px` value in the description field for easier internal reference/doc, but you don't need to parse that one