### PR TITLE
Remove color/hex transform and rely on ts/color/hexrgba

### DIFF
--- a/src/configs/getWebConfig.ts
+++ b/src/configs/getWebConfig.ts
@@ -32,7 +32,6 @@ export default function (target: "js" | "css" | "ts", theme: Theme): Platform {
     "ts/typography/css/shorthand",
     "ts/shadow/shorthand",
     "attribute/cti",
-    "color/hex",
     "css/pxToRem",
     "css/percentageToUnitless",
     target === "css" ? "name/cti/kebab" : "camelCaseDecimal",


### PR DESCRIPTION
Fixes https://github.com/vector-im/compound/issues/81

Web was applying two transforms `ts/color/hexrgba` and then tranforming it again using `color/hex` which would remove all alpha channels... 

Android and iOS both embed the alpha channel for all of the color definition by default