### PR TITLE
Support for semantics override

### DIFF
--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -35,6 +35,7 @@ export function getStyleDictionaryConfig(
     `tokens/platform-${platform}.json`,
     `tokens/theme-${theme}.json`,
     `tokens/theme-semantics.json`,
+    `tokens/theme-${theme}-semantics.json`,
     `icons/$icons.json`,
   ]);
 

--- a/src/filters/isCoreToken.ts
+++ b/src/filters/isCoreToken.ts
@@ -27,6 +27,6 @@ export default {
      * all tokens that are not in the semantics files are "core" and should
      * only be used directly under rare occasions
      */
-    return token.filePath.indexOf("theme-semantics") < 0;
+    return !token.filePath.endsWith("-semantics");
   },
 } as StyleDictionary.Filter;


### PR DESCRIPTION
Fixes https://github.com/vector-im/compound/issues/75

Support for token generation when the symetric semantics assignment does not yield satisfactory results.
This let you define token override per theme

@janogarcia to commit the first overrides on tokens.studio

The file names should be `theme-${THEME_NAME}-semantics.json` (e.g. `theme-light-hc-semantics.json`).