### PR TITLE
Update `lineHeightStyle` on Android typography token to match Figma

### DIFF
--- a/assets/android/SemanticColors.kt
+++ b/assets/android/SemanticColors.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.graphics.Color
 
 
 // Do not edit directly
-// Generated on Wed, 28 Jun 2023 10:55:55 GMT
+// Generated on Fri, 28 Jul 2023 10:11:16 GMT
 
 
 

--- a/assets/android/TypographyTokens.kt
+++ b/assets/android/TypographyTokens.kt
@@ -1,7 +1,7 @@
 
 
 // Do not edit directly
-// Generated on Wed, 28 Jun 2023 10:55:55 GMT
+// Generated on Fri, 28 Jul 2023 10:11:16 GMT
 
 
 
@@ -13,6 +13,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.style.LineHeightStyle
 
 object TypographyTokens {
   val fontBodyLgMedium = TextStyle(
@@ -21,6 +23,8 @@ object TypographyTokens {
         lineHeight = 22.sp,
         fontSize = 16.sp,
         letterSpacing = 0.015629999999999998.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontBodyLgRegular = TextStyle(
         fontFamily = FontFamily.Default,
@@ -28,6 +32,8 @@ object TypographyTokens {
         lineHeight = 22.sp,
         fontSize = 16.sp,
         letterSpacing = 0.015629999999999998.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontBodyMdMedium = TextStyle(
         fontFamily = FontFamily.Default,
@@ -35,6 +41,8 @@ object TypographyTokens {
         lineHeight = 20.sp,
         fontSize = 14.sp,
         letterSpacing = 0.01786.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontBodyMdRegular = TextStyle(
         fontFamily = FontFamily.Default,
@@ -42,6 +50,8 @@ object TypographyTokens {
         lineHeight = 20.sp,
         fontSize = 14.sp,
         letterSpacing = 0.01786.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontBodySmMedium = TextStyle(
         fontFamily = FontFamily.Default,
@@ -49,6 +59,8 @@ object TypographyTokens {
         lineHeight = 17.sp,
         fontSize = 12.sp,
         letterSpacing = 0.03333.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontBodySmRegular = TextStyle(
         fontFamily = FontFamily.Default,
@@ -56,6 +68,8 @@ object TypographyTokens {
         lineHeight = 17.sp,
         fontSize = 12.sp,
         letterSpacing = 0.03333.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontBodyXsMedium = TextStyle(
         fontFamily = FontFamily.Default,
@@ -63,6 +77,8 @@ object TypographyTokens {
         lineHeight = 15.sp,
         fontSize = 11.sp,
         letterSpacing = 0.04545.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontBodyXsRegular = TextStyle(
         fontFamily = FontFamily.Default,
@@ -70,6 +86,8 @@ object TypographyTokens {
         lineHeight = 15.sp,
         fontSize = 11.sp,
         letterSpacing = 0.04545.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontHeadingLgBold = TextStyle(
         fontFamily = FontFamily.Default,
@@ -77,6 +95,8 @@ object TypographyTokens {
         lineHeight = 34.sp,
         fontSize = 28.sp,
         letterSpacing = 0.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontHeadingLgRegular = TextStyle(
         fontFamily = FontFamily.Default,
@@ -84,6 +104,8 @@ object TypographyTokens {
         lineHeight = 34.sp,
         fontSize = 28.sp,
         letterSpacing = 0.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontHeadingMdBold = TextStyle(
         fontFamily = FontFamily.Default,
@@ -91,6 +113,8 @@ object TypographyTokens {
         lineHeight = 27.sp,
         fontSize = 22.sp,
         letterSpacing = 0.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontHeadingMdRegular = TextStyle(
         fontFamily = FontFamily.Default,
@@ -98,6 +122,8 @@ object TypographyTokens {
         lineHeight = 27.sp,
         fontSize = 22.sp,
         letterSpacing = 0.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontHeadingSmMedium = TextStyle(
         fontFamily = FontFamily.Default,
@@ -105,6 +131,8 @@ object TypographyTokens {
         lineHeight = 25.sp,
         fontSize = 20.sp,
         letterSpacing = 0.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontHeadingSmRegular = TextStyle(
         fontFamily = FontFamily.Default,
@@ -112,6 +140,8 @@ object TypographyTokens {
         lineHeight = 25.sp,
         fontSize = 20.sp,
         letterSpacing = 0.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontHeadingXlBold = TextStyle(
         fontFamily = FontFamily.Default,
@@ -119,6 +149,8 @@ object TypographyTokens {
         lineHeight = 41.sp,
         fontSize = 34.sp,
         letterSpacing = 0.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
     val fontHeadingXlRegular = TextStyle(
         fontFamily = FontFamily.Default,
@@ -126,5 +158,7 @@ object TypographyTokens {
         lineHeight = 41.sp,
         fontSize = 34.sp,
         letterSpacing = 0.em,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+        lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)
     )
 }

--- a/assets/android/internal/DarkDesignTokens.kt
+++ b/assets/android/internal/DarkDesignTokens.kt
@@ -1,7 +1,7 @@
 
 
 // Do not edit directly
-// Generated on Wed, 28 Jun 2023 10:55:54 GMT
+// Generated on Fri, 28 Jul 2023 10:11:16 GMT
 
 
 

--- a/assets/android/internal/DarkHcDesignTokens.kt
+++ b/assets/android/internal/DarkHcDesignTokens.kt
@@ -1,7 +1,7 @@
 
 
 // Do not edit directly
-// Generated on Wed, 28 Jun 2023 10:55:55 GMT
+// Generated on Fri, 28 Jul 2023 10:11:16 GMT
 
 
 

--- a/assets/android/internal/LightDesignTokens.kt
+++ b/assets/android/internal/LightDesignTokens.kt
@@ -1,7 +1,7 @@
 
 
 // Do not edit directly
-// Generated on Wed, 28 Jun 2023 10:55:54 GMT
+// Generated on Fri, 28 Jul 2023 10:11:16 GMT
 
 
 

--- a/assets/android/internal/LightHcDesignTokens.kt
+++ b/assets/android/internal/LightHcDesignTokens.kt
@@ -1,7 +1,7 @@
 
 
 // Do not edit directly
-// Generated on Wed, 28 Jun 2023 10:55:54 GMT
+// Generated on Fri, 28 Jul 2023 10:11:16 GMT
 
 
 

--- a/src/configs/getAndroidConfig.ts
+++ b/src/configs/getAndroidConfig.ts
@@ -135,7 +135,9 @@ export function getCommonAndroidConfig(): Platform {
             "androidx.compose.ui.text.font.FontWeight",
             "androidx.compose.ui.text.TextStyle",
             "androidx.compose.ui.unit.em",
-            "androidx.compose.ui.unit.sp"
+            "androidx.compose.ui.unit.sp",
+            "androidx.compose.ui.text.PlatformTextStyle",
+            "androidx.compose.ui.text.style.LineHeightStyle"
           ],
         }),
       },

--- a/src/transforms/kotlin/typography.ts
+++ b/src/transforms/kotlin/typography.ts
@@ -22,11 +22,13 @@ export default {
       paragraphIndent: "textIndent",
     };
 
-    return (
+    let ARG_INDENT_LEVEL = ANDROID_INDENT_LEVEL + ANDROID_INDENT_LEVEL;
+
+    let output =
       Object.entries(token.value).reduce((props, [propName, val]) => {
         let output = props;
         if (textStylePropertiesMapping[propName]) {
-          output += `${ANDROID_INDENT_LEVEL + ANDROID_INDENT_LEVEL + textStylePropertiesMapping[propName]} = `;
+          output += `${ARG_INDENT_LEVEL + textStylePropertiesMapping[propName]} = `;
           if (propName === "fontFamily") {
             output += "FontFamily.Default";
           } else {
@@ -36,7 +38,11 @@ export default {
         }
 
         return output;
-      }, "TextStyle(\n") + ANDROID_INDENT_LEVEL + ")"
-    );
+      }, "TextStyle(\n");
+
+      output += ARG_INDENT_LEVEL + "platformStyle = PlatformTextStyle(includeFontPadding = false),\n"
+      output += ARG_INDENT_LEVEL + "lineHeightStyle = LineHeightStyle(LineHeightStyle.Alignment.Center, LineHeightStyle.Trim.None)\n"
+    
+      return output + ANDROID_INDENT_LEVEL + ")";
   },
 } as StyleDictionary.Transform;


### PR DESCRIPTION
The `lineHeightStyle` for Material 3 components was changed in the latest version of the Android library, so we need to update our tokens too to keep a consistent state, matching what we see in the Figma designs.

More info [here](https://medium.com/androiddevelopers/fixing-font-padding-in-compose-text-768cd232425b).

An example of what upgrading the library version without fixing this issue looks like:

<details>
<summary>Diff screenshot</summary>
<img width="1711" alt="image" src="https://github.com/vector-im/compound-design-tokens/assets/480955/955bbd4c-8774-48e7-8bf0-a9dcf147c1a0">
</details>
